### PR TITLE
Expired elpa key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ elpa-key:
 	    if gpg -q --homedir $(HOME)/.emacs.d/elpa/gnupg -k | grep 81E42C40 ; then \
 	      exit 0 ; \
 	    fi ; \
-	    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir $(HOME)/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 ; \
 	    if [ $i -gt 1 ] ; then sleep 5 ; fi ; \
+	    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir $(HOME)/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 ; \
 	  done ; \
 	  exit 1 ; \
 	)

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ elpa-key:
 	-mkdir -p $(HOME)/.emacs.d/elpa/gnupg
 	chmod 700 $(HOME)/.emacs.d/elpa/gnupg
 	( for i in 1 2 3 ; do \
-	    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir $(HOME)/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 ; \
 	    if gpg -q --homedir $(HOME)/.emacs.d/elpa/gnupg -k | grep 81E42C40 ; then \
 	      exit 0 ; \
 	    fi ; \
-	    sleep 5 ; \
+	    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir $(HOME)/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 ; \
+	    if [ $i -gt 1 ] ; then sleep 5 ; fi ; \
 	  done ; \
 	  exit 1 ; \
 	)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ elpa-key:
 	    if gpg -q --homedir $(HOME)/.emacs.d/elpa/gnupg -k | grep 81E42C40 ; then \
 	      exit 0 ; \
 	    fi ; \
-	    if [ $i -gt 1 ] ; then sleep 5 ; fi ; \
+	    if [ $$i -gt 1 ] ; then sleep 5 ; fi ; \
 	    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir $(HOME)/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 ; \
 	  done ; \
 	  exit 1 ; \


### PR DESCRIPTION
The elpa key expiration has wrought havoc among elisp repos that actually conduct proper testing, proving once again that no good deed goes unpunished.
